### PR TITLE
Remove purchase flow and show presale closed message

### DIFF
--- a/index.html
+++ b/index.html
@@ -426,79 +426,10 @@
             <span style="font-size: 0.8em; color: var(--medium-gray);">(Available only in US & Canada)</span>
           </div>
 
-  <!-- Super Deal Price Card (to be inserted at the top of pricing-section) -->
-  <div class="option-card super-deal">
-    <div class="super-deal-badge">
-      <span>FLASH</span>
-      <span>SALE</span>
-    </div>
-    <h3>Limited Time Flash Sale<span class="discount-badge">80% OFF</span></h3>
-    <div class="price-display">
-      <span class="original-price">$499</span>
-      $99
-    </div>
-    <div class="time-left">
-      Offer expires in:
-    </div>
-    <div class="card-countdown-container" id="card-countdown">
-      <div class="card-countdown-unit">
-        <span class="card-countdown-value" id="card-days">03</span>
-        <span class="card-countdown-label">Days</span>
-      </div>
-      <div class="card-countdown-unit">
-        <span class="card-countdown-value" id="card-hours">00</span>
-        <span class="card-countdown-label">Hours</span>
-      </div>
-      <div class="card-countdown-unit">
-        <span class="card-countdown-value" id="card-minutes">00</span>
-        <span class="card-countdown-label">Minutes</span>
-      </div>
-      <div class="card-countdown-unit">
-        <span class="card-countdown-value" id="card-seconds">00</span>
-        <span class="card-countdown-label">Seconds</span>
-      </div>
-    </div>
-    <p class="description">
-      For <strong>3 days only</strong>, get the revolutionary OneSpark at our lowest price ever! This unbeatable deal includes everything - same premium features, same shipping timeline in Q4 2025. Act fast before this offer disappears!
-    </p>
-    <button class="btn" id="flash-deal-button">Claim $99 Deal Now</button>
-  </div>
-    <!-- Super Deal Price Card (to be inserted at the top of pricing-section) -->
-
-          
-          <!-- Deposit -->
+          <!-- Presale closed message -->
           <div class="option-card">
-            <h3>Early Bird Offer<span class="discount-badge">30% OFF</span></h3>
-            <div class="price-display" id="deposit-price-display">
-              <span class="original-price" id="deposit-original-price">$499</span>
-              $349
-            </div>
-            <p class="description" id="deposit-description">
-              Get the Early Bird discount! Pay $49 today and just $300 later when your OneSpark ships in Q4 2025. That's a total of <strong>$349</strong> - a 30% savings off the retail price!
-            </p>
-            <button class="btn btn-deposit" id="deposit-button">Reserve Now</button>
-          </div>
-          
-          <!-- Buy Now -->
-          <div class="option-card">
-            <h3>Exclusive Offer<span class="discount-badge">40% OFF</span></h3>
-            <div class="price-display" id="buy-now-price-display">
-              <span class="original-price" id="buy-now-original-price">$499</span>
-              $299
-            </div>
-            
-            <!-- Add progress bar and spots counter -->
-            <div class="spots-progress-container">
-              <div class="spots-progress-bar">
-                <div class="spots-progress-fill" id="spots-progress-fill"></div>
-              </div>
-              <p class="spots-counter" id="spots-counter">Spots available: <span id="spots-available">10</span>/<span id="spots-total">10</span></p>
-            </div>
-            
-            <p class="description">
-              Limited-time offer! Pay in full now and save 40%. Get your OneSpark at the lowest price possible, guaranteed. Your device will ship as soon as production completes in Q4 2025.
-            </p>
-            <button class="btn btn-buy" id="buy-now-button">Buy Now & Save</button>
+            <h3>Presale Closed</h3>
+            <p class="description">Thank you for your support! The presale has ended.</p>
           </div>
           </div>
         </div>

--- a/script.js
+++ b/script.js
@@ -673,13 +673,30 @@ document.addEventListener('DOMContentLoaded', async () => {
   }
 
   /* ----- Populate prices ----- */
-  document.getElementById('full-price-display').textContent = formatCurrency(FULL_PRICE);
-  document.getElementById('deposit-price-display').textContent = formatCurrency(depositAmount);
-  document.getElementById('deposit-description').innerHTML = 
-  "Get the Early Bird discount! Pay <strong>" + formatCurrency(depositAmount) + "</strong> today and just <strong>" + formatCurrency(349-depositAmount) + "</strong> later when your OneSpark ships in Q4 2025. That's a total of <strong>$349</strong> - a 30% savings off the retail price!";
-  document.getElementById('buy-now-original-price').textContent = formatCurrency(FULL_PRICE);
+  const fullPriceDisplay = document.getElementById('full-price-display');
+  if (fullPriceDisplay) fullPriceDisplay.textContent = formatCurrency(FULL_PRICE);
+
+  const depositPriceDisplay = document.getElementById('deposit-price-display');
+  if (depositPriceDisplay) depositPriceDisplay.textContent = formatCurrency(depositAmount);
+
+  const depositDescription = document.getElementById('deposit-description');
+  if (depositDescription) {
+    depositDescription.innerHTML =
+      "Get the Early Bird discount! Pay <strong>" +
+      formatCurrency(depositAmount) +
+      "</strong> today and just <strong>" +
+      formatCurrency(349 - depositAmount) +
+      "</strong> later when your OneSpark ships in Q4 2025. That's a total of <strong>$349</strong> - a 30% savings off the retail price!";
+  }
+
+  const buyNowOriginal = document.getElementById('buy-now-original-price');
+  if (buyNowOriginal) buyNowOriginal.textContent = formatCurrency(FULL_PRICE);
+
   const buyNowDisp = document.getElementById('buy-now-price-display');
-  buyNowDisp.childNodes[buyNowDisp.childNodes.length-1].nodeValue = ` ${formatCurrency(discountedPrice)}`;
+  if (buyNowDisp) {
+    buyNowDisp.childNodes[buyNowDisp.childNodes.length - 1].nodeValue =
+      ` ${formatCurrency(discountedPrice)}`;
+  }
 
   // Fetch max spots environment variable
   fetch('/api/get-config')


### PR DESCRIPTION
## Summary
- remove flash sale, deposit, and buy now cards
- show single card indicating presale closed
- guard price update code so it runs only when the related elements are present

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68628628dc34832988c3124ebbc3f5f1